### PR TITLE
Replace basic auth with passkey authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ docker compose up -d
 
 Access the app at http://localhost:8010
 
+## Authentication
+
+Postalgic protects the admin UI with a passkey. The first time you visit the
+app you'll be guided through a one-time setup wizard to register a passkey
+with your password manager (1Password, Apple Keychain, Bitwarden, etc.).
+
+WebAuthn requires HTTPS — most browsers won't allow passkey ceremonies on
+plain HTTP from a non-localhost address. If you're serving Postalgic over
+plain HTTP from another machine, uncomment `BASIC_AUTH_USERNAME` /
+`BASIC_AUTH_PASSWORD` in `docker-compose.yml` to fall back to HTTP basic auth.
+
+**Lost your passkey?** With Postalgic stopped, delete the row from
+`auth_credentials` in `data/postalgic.db`:
+
+```bash
+sqlite3 data/postalgic.db "DELETE FROM auth_credentials;"
+```
+
+Restarting will return you to the setup wizard.
+
 ## Development
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=8010
+      # Auth: Postalgic uses passkeys by default. The first time you visit the
+      # web app you'll be prompted to register one. WebAuthn requires HTTPS
+      # (browsers exempt localhost). If you serve Postalgic over plain HTTP
+      # from another machine, uncomment these to fall back to basic auth:
       # - BASIC_AUTH_USERNAME=admin
       # - BASIC_AUTH_PASSWORD=changeme
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@aws-sdk/client-cloudfront": "^3.700.0",
         "@aws-sdk/client-s3": "^3.700.0",
+        "@simplewebauthn/server": "^13.3.0",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "better-sqlite3": "^11.6.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "marked": "^15.0.0",
@@ -1536,6 +1538,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@img/colour": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
@@ -2081,6 +2089,180 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2436,6 +2618,25 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -3462,6 +3663,20 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4144,6 +4359,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -6317,6 +6551,24 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -6420,6 +6672,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7380,6 +7638,24 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.700.0",
     "@aws-sdk/client-s3": "^3.700.0",
+    "@simplewebauthn/server": "^13.3.0",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "better-sqlite3": "^11.6.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "marked": "^15.0.0",

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,78 @@
+import crypto from 'crypto';
+import { unsignValue } from '../utils/authStore.js';
+
+const SESSION_COOKIE = 'postalgic_session';
+
+/**
+ * True when basic auth env vars are configured. In that mode the legacy basic
+ * auth check is used and passkey auth is disabled.
+ */
+export function basicAuthConfigured() {
+  return Boolean(process.env.BASIC_AUTH_USERNAME && process.env.BASIC_AUTH_PASSWORD);
+}
+
+/**
+ * Returns the basic-auth middleware (only call when basicAuthConfigured() is true).
+ */
+export function basicAuthMiddleware() {
+  const username = process.env.BASIC_AUTH_USERNAME;
+  const password = process.env.BASIC_AUTH_PASSWORD;
+  return (req, res, next) => {
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith('Basic ')) {
+      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
+      const colonIndex = decoded.indexOf(':');
+      if (colonIndex !== -1) {
+        const user = decoded.slice(0, colonIndex);
+        const pass = decoded.slice(colonIndex + 1);
+        const userBuf = Buffer.from(user);
+        const passBuf = Buffer.from(pass);
+        const expectedUserBuf = Buffer.from(username);
+        const expectedPassBuf = Buffer.from(password);
+        if (
+          userBuf.length === expectedUserBuf.length &&
+          passBuf.length === expectedPassBuf.length &&
+          crypto.timingSafeEqual(userBuf, expectedUserBuf) &&
+          crypto.timingSafeEqual(passBuf, expectedPassBuf)
+        ) {
+          return next();
+        }
+      }
+    }
+    res.set('WWW-Authenticate', 'Basic realm="Postalgic"');
+    res.status(401).send('Authentication required');
+  };
+}
+
+/**
+ * Read the parsed session cookie and return true if it has a valid signature.
+ */
+export function isAuthenticated(req) {
+  const raw = req.cookies?.[SESSION_COOKIE];
+  if (!raw) return false;
+  return unsignValue(raw) !== null;
+}
+
+/**
+ * Passkey gate. /api/auth/* is always public so the SPA can drive the login
+ * and setup flows. All other API requests, plus /preview and /uploads (admin-
+ * only resources), require a valid signed session cookie. The SPA shell itself
+ * is served without auth so the login UI can load.
+ */
+export function passkeyGate() {
+  return (req, res, next) => {
+    if (req.path.startsWith('/api/auth/')) return next();
+    const needsAuth =
+      req.path.startsWith('/api/') ||
+      req.path.startsWith('/preview/') ||
+      req.path.startsWith('/uploads/');
+    if (!needsAuth) return next();
+    if (isAuthenticated(req)) return next();
+    if (req.path.startsWith('/api/')) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    return res.status(401).send('Authentication required');
+  };
+}
+
+export const SESSION_COOKIE_NAME = SESSION_COOKIE;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,303 @@
+/**
+ * Auth Routes
+ *
+ * Single-admin passkey auth. The first time the app is launched no credential
+ * exists, so the registration endpoints are open. Once a passkey is registered,
+ * registration requires an existing valid session (so a logged-in user can
+ * replace their passkey without going through the manual reset path).
+ *
+ * Recovery: delete the row in `auth_credentials` via sqlite3 to allow the
+ * setup wizard to run again.
+ */
+
+import express from 'express';
+import crypto from 'crypto';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse
+} from '@simplewebauthn/server';
+import {
+  hasAnyCredential,
+  listCredentials,
+  getCredentialByCredentialId,
+  saveCredential,
+  updateCredentialCounter,
+  deleteCredential,
+  deleteAllCredentials,
+  signValue,
+  unsignValue
+} from '../utils/authStore.js';
+import { isAuthenticated, SESSION_COOKIE_NAME } from '../middleware/auth.js';
+
+const router = express.Router();
+
+const RP_NAME = 'Postalgic';
+const CHALLENGE_COOKIE = 'postalgic_challenge';
+const CHALLENGE_TTL_SECONDS = 5 * 60;
+const SESSION_TTL_SECONDS = 365 * 24 * 60 * 60;
+
+function getRpId(req) {
+  // req.hostname uses X-Forwarded-Host when trust proxy is enabled, so this
+  // matches the host the browser saw during the ceremony.
+  return req.hostname;
+}
+
+function getOrigin(req) {
+  // Prefer X-Forwarded-Host so we match the browser-facing origin when sitting
+  // behind a reverse proxy (or the Vite dev proxy). Fall back to Host.
+  const host = req.get('x-forwarded-host') || req.get('host');
+  return `${req.protocol}://${host}`;
+}
+
+function setChallengeCookie(res, payload) {
+  const value = signValue(JSON.stringify(payload));
+  res.cookie(CHALLENGE_COOKIE, value, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: false,
+    maxAge: CHALLENGE_TTL_SECONDS * 1000,
+    path: '/api/auth'
+  });
+}
+
+function readChallengeCookie(req) {
+  const raw = req.cookies?.[CHALLENGE_COOKIE];
+  if (!raw) return null;
+  const value = unsignValue(raw);
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function clearChallengeCookie(res) {
+  res.clearCookie(CHALLENGE_COOKIE, { path: '/api/auth' });
+}
+
+function setSessionCookie(res) {
+  const value = signValue(String(Date.now()));
+  res.cookie(SESSION_COOKIE_NAME, value, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: false,
+    maxAge: SESSION_TTL_SECONDS * 1000,
+    path: '/'
+  });
+}
+
+function clearSessionCookie(res) {
+  res.clearCookie(SESSION_COOKIE_NAME, { path: '/' });
+}
+
+/**
+ * GET /api/auth/status
+ * Public. Tells the SPA whether to show the setup wizard, login, or app.
+ */
+router.get('/status', (req, res) => {
+  res.json({
+    hasPasskey: hasAnyCredential(),
+    authenticated: isAuthenticated(req)
+  });
+});
+
+/**
+ * POST /api/auth/register/options
+ * Open if no passkey exists; otherwise requires an active session (used to
+ * replace the existing passkey).
+ */
+router.post('/register/options', async (req, res, next) => {
+  try {
+    const existing = hasAnyCredential();
+    if (existing && !isAuthenticated(req)) {
+      return res.status(401).json({ error: 'Authentication required to replace passkey' });
+    }
+
+    const userId = crypto.randomBytes(16);
+    const rpID = getRpId(req);
+
+    const options = await generateRegistrationOptions({
+      rpName: RP_NAME,
+      rpID,
+      userID: userId,
+      userName: 'admin',
+      userDisplayName: 'Postalgic Admin',
+      attestationType: 'none',
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'preferred'
+      }
+    });
+
+    setChallengeCookie(res, { type: 'register', challenge: options.challenge });
+    res.json(options);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/auth/register/verify
+ * Verifies the registration ceremony and stores the credential. Replaces any
+ * existing credential (single-passkey design).
+ */
+router.post('/register/verify', async (req, res, next) => {
+  try {
+    const existing = hasAnyCredential();
+    if (existing && !isAuthenticated(req)) {
+      return res.status(401).json({ error: 'Authentication required to replace passkey' });
+    }
+
+    const stored = readChallengeCookie(req);
+    if (!stored || stored.type !== 'register') {
+      return res.status(400).json({ error: 'Missing or invalid challenge — please retry' });
+    }
+
+    const verification = await verifyRegistrationResponse({
+      response: req.body,
+      expectedChallenge: stored.challenge,
+      expectedOrigin: getOrigin(req),
+      expectedRPID: getRpId(req)
+    });
+
+    if (!verification.verified || !verification.registrationInfo) {
+      clearChallengeCookie(res);
+      return res.status(400).json({ error: 'Passkey registration failed' });
+    }
+
+    const { credential } = verification.registrationInfo;
+    // Replace any existing credential (single-passkey design)
+    deleteAllCredentials();
+    saveCredential({
+      id: crypto.randomUUID(),
+      credentialId: credential.id,
+      publicKey: Buffer.from(credential.publicKey),
+      counter: credential.counter,
+      transports: credential.transports,
+      label: req.body?.label || null
+    });
+
+    clearChallengeCookie(res);
+    setSessionCookie(res);
+    res.json({ verified: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/auth/authenticate/options
+ * Public. Returns options for the auth ceremony.
+ */
+router.post('/authenticate/options', async (req, res, next) => {
+  try {
+    if (!hasAnyCredential()) {
+      return res.status(409).json({ error: 'No passkey is registered' });
+    }
+    const credentials = listCredentials();
+    const options = await generateAuthenticationOptions({
+      rpID: getRpId(req),
+      allowCredentials: credentials.map((c) => ({
+        id: c.credentialId,
+        transports: c.transports
+      })),
+      userVerification: 'preferred'
+    });
+
+    setChallengeCookie(res, { type: 'auth', challenge: options.challenge });
+    res.json(options);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/auth/authenticate/verify
+ * Verifies the auth ceremony and sets the session cookie.
+ */
+router.post('/authenticate/verify', async (req, res, next) => {
+  try {
+    const stored = readChallengeCookie(req);
+    if (!stored || stored.type !== 'auth') {
+      return res.status(400).json({ error: 'Missing or invalid challenge — please retry' });
+    }
+
+    const credentialId = req.body?.id;
+    if (!credentialId) {
+      return res.status(400).json({ error: 'Missing credential id' });
+    }
+    const stored_credential = getCredentialByCredentialId(credentialId);
+    if (!stored_credential) {
+      return res.status(404).json({ error: 'Unknown credential' });
+    }
+
+    const verification = await verifyAuthenticationResponse({
+      response: req.body,
+      expectedChallenge: stored.challenge,
+      expectedOrigin: getOrigin(req),
+      expectedRPID: getRpId(req),
+      credential: {
+        id: stored_credential.credentialId,
+        publicKey: stored_credential.publicKey,
+        counter: stored_credential.counter,
+        transports: stored_credential.transports
+      }
+    });
+
+    if (!verification.verified) {
+      clearChallengeCookie(res);
+      return res.status(400).json({ error: 'Authentication failed' });
+    }
+
+    updateCredentialCounter(stored_credential.credentialId, verification.authenticationInfo.newCounter);
+    clearChallengeCookie(res);
+    setSessionCookie(res);
+    res.json({ verified: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/auth/logout
+ */
+router.post('/logout', (req, res) => {
+  clearSessionCookie(res);
+  res.json({ ok: true });
+});
+
+/**
+ * GET /api/auth/passkey
+ * Authenticated. Returns the registered passkey (without keying material).
+ */
+router.get('/passkey', (req, res) => {
+  if (!isAuthenticated(req)) return res.status(401).json({ error: 'Authentication required' });
+  const credentials = listCredentials();
+  const c = credentials[0];
+  if (!c) return res.json({ passkey: null });
+  res.json({
+    passkey: {
+      id: c.id,
+      label: c.label,
+      createdAt: c.createdAt,
+      lastUsedAt: c.lastUsedAt
+    }
+  });
+});
+
+/**
+ * DELETE /api/auth/passkey
+ * Authenticated. Removes the registered passkey and ends the session.
+ * After this the next visit will land on the setup wizard.
+ */
+router.delete('/passkey', (req, res) => {
+  if (!isAuthenticated(req)) return res.status(401).json({ error: 'Authentication required' });
+  deleteAllCredentials();
+  clearSessionCookie(res);
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import crypto from 'crypto';
+import cookieParser from 'cookie-parser';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
@@ -8,6 +8,10 @@ import fs from 'fs';
 // Database
 import { initDatabase } from './utils/database.js';
 import { needsMigration, runMigration } from './utils/migration.js';
+
+// Auth
+import authRoutes from './routes/auth.js';
+import { basicAuthConfigured, basicAuthMiddleware, passkeyGate } from './middleware/auth.js';
 
 // Routes
 import blogRoutes from './routes/blogs.js';
@@ -46,41 +50,25 @@ if (needsMigration(DATA_ROOT)) {
   runMigration(DATA_ROOT);
 }
 
+// Trust the reverse proxy (so req.protocol / req.hostname reflect the
+// browser-facing origin when the app is served behind one — required for
+// WebAuthn RP ID and origin validation to match what the browser sees).
+app.set('trust proxy', true);
+
 // Middleware
 app.use(cors());
 app.use(express.json({ limit: '100mb' }));
 app.use(express.urlencoded({ extended: true, limit: '100mb' }));
+app.use(cookieParser());
 
-// Basic auth middleware (enabled via environment variables)
-const BASIC_AUTH_USERNAME = process.env.BASIC_AUTH_USERNAME;
-const BASIC_AUTH_PASSWORD = process.env.BASIC_AUTH_PASSWORD;
-
-if (BASIC_AUTH_USERNAME && BASIC_AUTH_PASSWORD) {
-  app.use((req, res, next) => {
-    const authHeader = req.headers.authorization;
-    if (authHeader && authHeader.startsWith('Basic ')) {
-      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
-      const colonIndex = decoded.indexOf(':');
-      if (colonIndex !== -1) {
-        const user = decoded.slice(0, colonIndex);
-        const pass = decoded.slice(colonIndex + 1);
-        const userBuf = Buffer.from(user);
-        const passBuf = Buffer.from(pass);
-        const expectedUserBuf = Buffer.from(BASIC_AUTH_USERNAME);
-        const expectedPassBuf = Buffer.from(BASIC_AUTH_PASSWORD);
-        if (
-          userBuf.length === expectedUserBuf.length &&
-          passBuf.length === expectedPassBuf.length &&
-          crypto.timingSafeEqual(userBuf, expectedUserBuf) &&
-          crypto.timingSafeEqual(passBuf, expectedPassBuf)
-        ) {
-          return next();
-        }
-      }
-    }
-    res.set('WWW-Authenticate', 'Basic realm="Postalgic"');
-    res.status(401).send('Authentication required');
-  });
+// Auth: legacy basic auth if env vars are set (intended for non-SSL deployments
+// where browsers will not allow WebAuthn), otherwise the passkey gate.
+const useBasicAuth = basicAuthConfigured();
+if (useBasicAuth) {
+  app.use(basicAuthMiddleware());
+} else {
+  app.use('/api/auth', authRoutes);
+  app.use(passkeyGate());
 }
 
 // Make data root available to routes
@@ -133,5 +121,5 @@ app.use((err, req, res, next) => {
 app.listen(PORT, () => {
   console.log(`Postalgic server running on http://localhost:${PORT}`);
   console.log(`Data directory: ${DATA_ROOT}`);
-  console.log(`Basic auth: ${BASIC_AUTH_USERNAME && BASIC_AUTH_PASSWORD ? 'enabled' : 'disabled'}`);
+  console.log(`Auth mode: ${useBasicAuth ? 'basic auth (legacy)' : 'passkey'}`);
 });

--- a/server/utils/authStore.js
+++ b/server/utils/authStore.js
@@ -1,0 +1,124 @@
+import crypto from 'crypto';
+import { getDatabase } from './database.js';
+
+const SESSION_SECRET_KEY = 'session_secret';
+
+let cachedSessionSecret = null;
+
+/**
+ * Get the session signing secret, generating and persisting one on first use.
+ */
+export function getSessionSecret() {
+  if (cachedSessionSecret) return cachedSessionSecret;
+  const db = getDatabase();
+  let row = db
+    .prepare('SELECT value FROM auth_settings WHERE key = ?')
+    .get(SESSION_SECRET_KEY);
+  if (!row) {
+    const secret = crypto.randomBytes(32).toString('base64url');
+    db.prepare('INSERT INTO auth_settings (key, value) VALUES (?, ?)').run(
+      SESSION_SECRET_KEY,
+      secret
+    );
+    row = { value: secret };
+  }
+  cachedSessionSecret = row.value;
+  return cachedSessionSecret;
+}
+
+/**
+ * HMAC-sign a value with the session secret. Returns "value.signature".
+ */
+export function signValue(value) {
+  const secret = getSessionSecret();
+  const sig = crypto.createHmac('sha256', secret).update(value).digest('base64url');
+  return `${value}.${sig}`;
+}
+
+/**
+ * Verify a signed value. Returns the original value or null if invalid.
+ */
+export function unsignValue(signed) {
+  if (typeof signed !== 'string') return null;
+  const idx = signed.lastIndexOf('.');
+  if (idx === -1) return null;
+  const value = signed.slice(0, idx);
+  const sig = signed.slice(idx + 1);
+  const secret = getSessionSecret();
+  const expected = crypto.createHmac('sha256', secret).update(value).digest('base64url');
+  if (sig.length !== expected.length) return null;
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null;
+  } catch {
+    return null;
+  }
+  return value;
+}
+
+export function listCredentials() {
+  const db = getDatabase();
+  return db
+    .prepare(
+      `SELECT id, credential_id, public_key, counter, transports, label, created_at, last_used_at
+       FROM auth_credentials ORDER BY created_at ASC`
+    )
+    .all()
+    .map(rowToCredential);
+}
+
+export function hasAnyCredential() {
+  const db = getDatabase();
+  const row = db.prepare('SELECT COUNT(*) as count FROM auth_credentials').get();
+  return row.count > 0;
+}
+
+export function getCredentialByCredentialId(credentialId) {
+  const db = getDatabase();
+  const row = db
+    .prepare(
+      `SELECT id, credential_id, public_key, counter, transports, label, created_at, last_used_at
+       FROM auth_credentials WHERE credential_id = ?`
+    )
+    .get(credentialId);
+  return row ? rowToCredential(row) : null;
+}
+
+export function saveCredential({ id, credentialId, publicKey, counter, transports, label }) {
+  const db = getDatabase();
+  const transportsJson = transports ? JSON.stringify(transports) : null;
+  db.prepare(
+    `INSERT INTO auth_credentials (id, credential_id, public_key, counter, transports, label, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(id, credentialId, publicKey, counter, transportsJson, label || null, new Date().toISOString());
+}
+
+export function updateCredentialCounter(credentialId, counter) {
+  const db = getDatabase();
+  db.prepare(
+    `UPDATE auth_credentials SET counter = ?, last_used_at = ? WHERE credential_id = ?`
+  ).run(counter, new Date().toISOString(), credentialId);
+}
+
+export function deleteCredential(id) {
+  const db = getDatabase();
+  const result = db.prepare('DELETE FROM auth_credentials WHERE id = ?').run(id);
+  return result.changes > 0;
+}
+
+export function deleteAllCredentials() {
+  const db = getDatabase();
+  db.prepare('DELETE FROM auth_credentials').run();
+}
+
+function rowToCredential(row) {
+  return {
+    id: row.id,
+    credentialId: row.credential_id,
+    publicKey: row.public_key,
+    counter: row.counter,
+    transports: row.transports ? JSON.parse(row.transports) : undefined,
+    label: row.label,
+    createdAt: row.created_at,
+    lastUsedAt: row.last_used_at
+  };
+}

--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -161,6 +161,38 @@ function runMigrations(database) {
     `);
   }
 
+  const authCredentialsExists = database.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='auth_credentials'
+  `).get();
+  if (!authCredentialsExists) {
+    console.log('[Database] Running migration: creating auth_credentials table');
+    database.exec(`
+      CREATE TABLE auth_credentials (
+        id TEXT PRIMARY KEY,
+        credential_id TEXT NOT NULL UNIQUE,
+        public_key BLOB NOT NULL,
+        counter INTEGER NOT NULL DEFAULT 0,
+        transports TEXT,
+        label TEXT,
+        created_at TEXT NOT NULL,
+        last_used_at TEXT
+      );
+    `);
+  }
+
+  const authSettingsExists = database.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='auth_settings'
+  `).get();
+  if (!authSettingsExists) {
+    console.log('[Database] Running migration: creating auth_settings table');
+    database.exec(`
+      CREATE TABLE auth_settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+  }
+
   const postSharesExists = database.prepare(`
     SELECT name FROM sqlite_master WHERE type='table' AND name='post_shares'
   `).get();
@@ -359,6 +391,24 @@ function createSchema(database) {
       config TEXT NOT NULL,
       created_at TEXT NOT NULL,
       updated_at TEXT
+    );
+
+    -- Passkey credentials (single-admin install; one or more passkeys may be registered)
+    CREATE TABLE auth_credentials (
+      id TEXT PRIMARY KEY,
+      credential_id TEXT NOT NULL UNIQUE,
+      public_key BLOB NOT NULL,
+      counter INTEGER NOT NULL DEFAULT 0,
+      transports TEXT,
+      label TEXT,
+      created_at TEXT NOT NULL,
+      last_used_at TEXT
+    );
+
+    -- Auth settings (e.g. session signing secret)
+    CREATE TABLE auth_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
     );
 
     -- Per-post share attempt log

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "postalgic-client",
       "version": "1.0.0",
       "dependencies": {
+        "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/typography": "^0.5.19",
         "@vueuse/core": "^11.0.0",
         "chart.js": "^4.4.0",
@@ -856,6 +857,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.19",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/typography": "^0.5.19",
     "@vueuse/core": "^11.0.0",
     "chart.js": "^4.4.0",

--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -1,9 +1,32 @@
 <script setup>
+import { onMounted } from 'vue';
 import { RouterView } from 'vue-router';
+import { useAuth, refreshAuthStatus } from '@/composables/useAuth';
+import AuthSetupView from '@/views/AuthSetupView.vue';
+import AuthLoginView from '@/views/AuthLoginView.vue';
+
+const auth = useAuth();
+
+onMounted(() => {
+  refreshAuthStatus();
+});
 </script>
 
 <template>
   <div class="min-h-screen bg-site-bg">
-    <RouterView />
+    <template v-if="!auth.loaded">
+      <div class="min-h-screen flex items-center justify-center text-site-medium text-[0.9em]">
+        Loading…
+      </div>
+    </template>
+    <template v-else-if="!auth.hasPasskey">
+      <AuthSetupView />
+    </template>
+    <template v-else-if="!auth.authenticated">
+      <AuthLoginView />
+    </template>
+    <template v-else>
+      <RouterView />
+    </template>
   </div>
 </template>

--- a/vue_client/src/api/index.js
+++ b/vue_client/src/api/index.js
@@ -1,13 +1,20 @@
+import { onSessionExpired } from '@/composables/useAuth';
+
 const API_BASE = '/api';
 
 async function fetchApi(url, options = {}) {
   const response = await fetch(`${API_BASE}${url}`, {
+    credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
       ...options.headers
     },
     ...options
   });
+
+  if (response.status === 401 && !url.startsWith('/auth/')) {
+    onSessionExpired();
+  }
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Unknown error' }));

--- a/vue_client/src/composables/useAuth.js
+++ b/vue_client/src/composables/useAuth.js
@@ -1,0 +1,90 @@
+import { reactive } from 'vue';
+import {
+  startRegistration,
+  startAuthentication
+} from '@simplewebauthn/browser';
+
+const state = reactive({
+  loaded: false,
+  hasPasskey: false,
+  authenticated: false,
+  basicAuth: false
+});
+
+async function fetchJson(url, options = {}) {
+  const res = await fetch(url, {
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options
+  });
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  if (!res.ok) {
+    throw new Error(body?.error || `HTTP ${res.status}`);
+  }
+  return body;
+}
+
+export async function refreshAuthStatus() {
+  try {
+    const data = await fetchJson('/api/auth/status');
+    state.hasPasskey = !!data.hasPasskey;
+    state.authenticated = !!data.authenticated;
+    state.basicAuth = false;
+  } catch (err) {
+    // If /api/auth/status itself returns 404, basic auth mode is in effect
+    // and the browser handled it transparently — we're authenticated.
+    state.hasPasskey = false;
+    state.authenticated = true;
+    state.basicAuth = true;
+  } finally {
+    state.loaded = true;
+  }
+}
+
+export async function registerPasskey() {
+  const options = await fetchJson('/api/auth/register/options', {
+    method: 'POST',
+    body: JSON.stringify({})
+  });
+  const attResp = await startRegistration({ optionsJSON: options });
+  await fetchJson('/api/auth/register/verify', {
+    method: 'POST',
+    body: JSON.stringify(attResp)
+  });
+  await refreshAuthStatus();
+}
+
+export async function loginWithPasskey() {
+  const options = await fetchJson('/api/auth/authenticate/options', {
+    method: 'POST',
+    body: JSON.stringify({})
+  });
+  const authResp = await startAuthentication({ optionsJSON: options });
+  await fetchJson('/api/auth/authenticate/verify', {
+    method: 'POST',
+    body: JSON.stringify(authResp)
+  });
+  await refreshAuthStatus();
+}
+
+export async function logout() {
+  try {
+    await fetchJson('/api/auth/logout', { method: 'POST', body: JSON.stringify({}) });
+  } finally {
+    await refreshAuthStatus();
+  }
+}
+
+export function useAuth() {
+  return state;
+}
+
+/** Mark the session as expired (e.g., when an API call returns 401). */
+export function onSessionExpired() {
+  state.authenticated = false;
+}

--- a/vue_client/src/views/AuthLoginView.vue
+++ b/vue_client/src/views/AuthLoginView.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { loginWithPasskey } from '@/composables/useAuth';
+
+const busy = ref(false);
+const error = ref('');
+
+async function handleLogin() {
+  busy.value = true;
+  error.value = '';
+  try {
+    await loginWithPasskey();
+  } catch (err) {
+    // Browser cancellations look like NotAllowedError or AbortError — keep
+    // the message friendly so it doesn't read like a real failure.
+    const name = err?.name || '';
+    if (name === 'NotAllowedError' || name === 'AbortError') {
+      error.value = 'Sign-in was cancelled.';
+    } else {
+      error.value = err?.message || 'Sign-in failed';
+    }
+  } finally {
+    busy.value = false;
+  }
+}
+
+onMounted(() => {
+  // Auto-trigger the passkey prompt so the user lands straight in the
+  // password-manager dialog instead of having to click twice.
+  handleLogin();
+});
+</script>
+
+<template>
+  <div class="min-h-screen bg-site-bg text-site-text flex items-center justify-center px-6 py-12">
+    <div class="max-w-md w-full">
+      <div class="text-center mb-8">
+        <img src="/postalgic-logo.png" alt="Postalgic" class="h-16 mx-auto mb-6" />
+        <h1 class="text-[1.6rem] font-bold text-site-dark mb-3">Sign in</h1>
+        <p class="text-[0.95em] text-site-medium leading-relaxed">
+          Use your passkey to continue.
+        </p>
+      </div>
+
+      <div class="bg-white border border-site-light rounded-lg p-6">
+        <button
+          @click="handleLogin"
+          :disabled="busy"
+          class="w-full px-5 py-3 bg-site-accent text-white font-semibold rounded-full hover:bg-[#e89200] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          {{ busy ? 'Signing in…' : 'Sign in with passkey' }}
+        </button>
+
+        <p v-if="error" class="mt-4 text-[0.9em] text-red-600">
+          {{ error }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/vue_client/src/views/AuthSetupView.vue
+++ b/vue_client/src/views/AuthSetupView.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { ref } from 'vue';
+import { registerPasskey } from '@/composables/useAuth';
+
+const busy = ref(false);
+const error = ref('');
+
+async function handleRegister() {
+  busy.value = true;
+  error.value = '';
+  try {
+    await registerPasskey();
+  } catch (err) {
+    error.value = err?.message || 'Failed to register passkey';
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-site-bg text-site-text flex items-center justify-center px-6 py-12">
+    <div class="max-w-md w-full">
+      <div class="text-center mb-8">
+        <img src="/postalgic-logo.png" alt="Postalgic" class="h-16 mx-auto mb-6" />
+        <h1 class="text-[1.6rem] font-bold text-site-dark mb-3">Welcome to Postalgic</h1>
+        <p class="text-[0.95em] text-site-medium leading-relaxed">
+          Set up a passkey to secure your install. Your password manager (1Password,
+          Apple Keychain, Bitwarden, etc.) will store it and let you sign in from any device.
+        </p>
+      </div>
+
+      <div class="bg-white border border-site-light rounded-lg p-6">
+        <button
+          @click="handleRegister"
+          :disabled="busy"
+          class="w-full px-5 py-3 bg-site-accent text-white font-semibold rounded-full hover:bg-[#e89200] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          {{ busy ? 'Setting up…' : 'Create passkey' }}
+        </button>
+
+        <p v-if="error" class="mt-4 text-[0.9em] text-red-600">
+          {{ error }}
+        </p>
+
+        <p class="mt-6 text-[0.8em] text-site-medium leading-relaxed">
+          Passkeys require an HTTPS connection (or localhost). If your install is on
+          plain HTTP from another machine, set the <code>BASIC_AUTH_USERNAME</code> and
+          <code>BASIC_AUTH_PASSWORD</code> environment variables to fall back to
+          username + password instead.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/vue_client/src/views/HomeView.vue
+++ b/vue_client/src/views/HomeView.vue
@@ -13,6 +13,9 @@ import { ref, onMounted, onUnmounted, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import { useBlogStore } from '@/stores/blog';
 import { blogApi } from '@/api';
+import { useAuth, logout } from '@/composables/useAuth';
+
+const auth = useAuth();
 
 const router = useRouter();
 const blogStore = useBlogStore();
@@ -172,18 +175,28 @@ async function deleteBlog() {
     <header class="max-w-[1000px] mx-auto px-8 pt-8 pb-4">
       <div class="flex items-center justify-between mb-4">
         <img src="/postalgic-logo.png" alt="Postalgic" class="h-16" />
-        <div class="relative group">
-          <button class="px-5 py-2 bg-site-accent text-white font-semibold rounded-full hover:bg-[#e89200] transition-colors">
-            + New Blog
+        <div class="flex items-center gap-3">
+          <button
+            v-if="!auth.basicAuth"
+            @click="logout"
+            class="px-3 py-2 text-[0.85em] text-site-medium hover:text-site-accent transition-colors"
+            title="Sign out"
+          >
+            Sign out
           </button>
-          <div class="absolute right-0 top-full hidden group-hover:block z-20 pt-1">
-            <div class="bg-white border border-site-light rounded-lg min-w-[200px] shadow-lg overflow-hidden">
-              <router-link to="/blogs/new" class="block px-4 py-3 text-site-text hover:bg-site-accent hover:text-white transition-colors">
-                New Blog
-              </router-link>
-              <router-link to="/blogs/import" class="block px-4 py-3 text-site-text hover:bg-site-accent hover:text-white transition-colors border-t border-site-light">
-                Import from ZIP
-              </router-link>
+          <div class="relative group">
+            <button class="px-5 py-2 bg-site-accent text-white font-semibold rounded-full hover:bg-[#e89200] transition-colors">
+              + New Blog
+            </button>
+            <div class="absolute right-0 top-full hidden group-hover:block z-20 pt-1">
+              <div class="bg-white border border-site-light rounded-lg min-w-[200px] shadow-lg overflow-hidden">
+                <router-link to="/blogs/new" class="block px-4 py-3 text-site-text hover:bg-site-accent hover:text-white transition-colors">
+                  New Blog
+                </router-link>
+                <router-link to="/blogs/import" class="block px-4 py-3 text-site-text hover:bg-site-accent hover:text-white transition-colors border-t border-site-light">
+                  Import from ZIP
+                </router-link>
+              </div>
             </div>
           </div>
         </div>

--- a/vue_client/vite.config.js
+++ b/vue_client/vite.config.js
@@ -12,17 +12,24 @@ export default defineConfig({
   server: {
     port: 5188,
     proxy: {
+      // xfwd: true forwards the browser-facing host (localhost:5188) as
+      // X-Forwarded-Host. Without this, WebAuthn origin verification fails
+      // in dev because the credential is bound to :5188 but the proxy
+      // rewrites Host to :8010.
       '/api': {
         target: 'http://localhost:8010',
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       },
       '/uploads': {
         target: 'http://localhost:8010',
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       },
       '/preview': {
         target: 'http://localhost:8010',
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: true
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replaces the inline basic auth middleware with passkey (WebAuthn) auth and a one-time setup wizard on first launch
- Sessions use a 1-year HMAC-signed cookie (single-passkey, single-admin model)
- Basic auth stays available as an opt-in fallback for non-SSL deployments — set `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` to use it
- Recovery: with the server stopped, `sqlite3 data/postalgic.db "DELETE FROM auth_credentials;"` returns to the setup wizard

## What changed
- **Server**: new `server/routes/auth.js` (status, register, authenticate, logout, passkey), `server/middleware/auth.js` (basic-auth fallback + passkey gate that protects `/api/*` plus `/preview` and `/uploads`), `server/utils/authStore.js`, new `auth_credentials` and `auth_settings` tables (with migrations), `app.set('trust proxy', true)` so RP ID / origin reflect the browser-facing host behind a reverse proxy
- **Client**: `composables/useAuth.js`, `AuthSetupView.vue`, `AuthLoginView.vue`; `App.vue` gates RouterView on auth status; sign-out button in `HomeView`; `api/index.js` flags 401 to bounce back to login
- **Dev**: `vite.config.js` now sets `xfwd: true` on the proxy so the backend sees the browser-facing host (otherwise WebAuthn origin verification would fail in dev)
- **Docs**: README explains the passkey flow, the basic-auth fallback for HTTP-only setups, and the recovery command; `docker-compose.yml` env block updated

## Test plan
- [ ] Fresh install → setup wizard appears → register passkey via password manager → app loads
- [ ] Refresh the page → still authenticated (cookie sticks)
- [ ] Sign out → login screen → sign back in
- [ ] Stop server, run `sqlite3 data/postalgic.db "DELETE FROM auth_credentials;"`, restart → setup wizard appears again
- [ ] Set `BASIC_AUTH_USERNAME` + `BASIC_AUTH_PASSWORD` → app uses basic auth, passkey routes are not mounted
- [ ] `/api/blogs`, `/preview`, `/uploads` return 401 to unauthenticated callers; SPA shell still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)