### PR TITLE
Don't require user verification on passkey ceremonies

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -160,7 +160,11 @@ router.post('/register/verify', async (req, res, next) => {
       response: req.body,
       expectedChallenge: stored.challenge,
       expectedOrigin: getOrigin(req),
-      expectedRPID: getRpId(req)
+      expectedRPID: getRpId(req),
+      // Match the "preferred" UV setting on the options side: if the
+      // authenticator performed UV great, but don't reject when it didn't
+      // (e.g. desktop password managers without biometrics enabled).
+      requireUserVerification: false
     });
 
     if (!verification.verified || !verification.registrationInfo) {
@@ -239,6 +243,7 @@ router.post('/authenticate/verify', async (req, res, next) => {
       expectedChallenge: stored.challenge,
       expectedOrigin: getOrigin(req),
       expectedRPID: getRpId(req),
+      requireUserVerification: false,
       credential: {
         id: stored_credential.credentialId,
         publicKey: stored_credential.publicKey,


### PR DESCRIPTION
## Summary
- Fixes `Error: User verification was required, but user could not be verified` during passkey registration on the deployed image
- `@simplewebauthn/server` v13 defaults `requireUserVerification` to `true` on the verify side, which rejects authenticators that didn't perform UV (common with desktop password managers without biometrics enabled)
- The options side already advertises `userVerification: 'preferred'` — this aligns the verify side to match

## Test plan
- [ ] Register a passkey from a desktop password manager (e.g. Bitwarden without biometrics) — should now succeed
- [ ] Register from a device that does perform UV (e.g. Touch ID, Windows Hello) — should still succeed
- [ ] Sign back in after restart — should still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)